### PR TITLE
Delay light removal to reduce flickering

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,7 @@
 
+local ilumination_remove_light_dtime = minetest.settings:get("ilumination_remove_light_dtime")
+ilumination_remove_light_dtime = ilumination_remove_light_dtime and tonumber(ilumination_remove_light_dtime) or 0.3
+
 local player_lights = {}
 
 local function can_replace(pos)
@@ -6,9 +9,23 @@ local function can_replace(pos)
 	return nn == "air" or minetest.get_item_group(nn, "illumination_light") > 0
 end
 
+local function fix_light(pos)
+	local pmin = vector.subtract(pos, { x = 16, y = 16, z = 16 })
+	local pmax = vector.add(pos, { x = 16, y = 16, z = 16 })
+
+	return minetest.fix_light(pmin, pmax)
+end
+
 local function remove_light(pos)
-	if pos and can_replace(pos) then
-		minetest.set_node(pos, {name = "air"})
+	local nn = minetest.get_node(pos).name
+	if minetest.get_item_group(nn, "illumination_light") > 0 then
+		if ilumination_remove_light_dtime <= 0 then
+			minetest.set_node(pos, {name = "air"})
+			fix_light(pos)
+			return
+		end
+
+		minetest.get_node_timer(pos):start(ilumination_remove_light_dtime)
 	end
 end
 
@@ -68,6 +85,7 @@ local function update_illumination(player, dtime)
 		local new_pos = find_light_pos(pos)
 		if new_pos then
 			minetest.set_node(new_pos, {name = node})
+			minetest.get_node_timer(new_pos):stop()
 			if old_pos and not vector.equals(old_pos, new_pos) then
 				remove_light(old_pos)
 			end
@@ -76,7 +94,9 @@ local function update_illumination(player, dtime)
 		end
 	end
 	-- No illumination
-	remove_light(old_pos)
+	if old_pos then
+		remove_light(old_pos)
+	end
 	player_lights[name].pos = nil
 end
 
@@ -95,7 +115,7 @@ end)
 
 minetest.register_on_leaveplayer(function(player)
 	local name = player:get_player_name()
-	if player_lights[name] then
+	if player_lights[name] and player_lights[name].pos then
 		remove_light(player_lights[name].pos)
 	end
 	player_lights[name] = nil
@@ -124,6 +144,11 @@ if minetest.get_modpath("3d_armor") then
 	end)
 end
 
+local light_on_timer = function(pos)
+	minetest.set_node(pos, { name = "air" })
+	fix_light(pos)
+end
+
 -- Light node for every light level
 for n = 1, 14 do
 	minetest.register_node("illumination:light_"..n, {
@@ -140,6 +165,7 @@ for n = 1, 14 do
 			illumination_light = 1,
 		},
 		drop = "",
+		on_timer = light_on_timer,
 	})
 end
 
@@ -151,6 +177,7 @@ minetest.register_lbm({
 	run_at_every_load = true,
 	action = function(pos)
 		minetest.set_node(pos, {name = "air"})
+		fix_light(pos)
 	end,
 })
 

--- a/init.lua
+++ b/init.lua
@@ -1,6 +1,5 @@
 
-local ilumination_remove_light_dtime = minetest.settings:get("ilumination_remove_light_dtime")
-ilumination_remove_light_dtime = ilumination_remove_light_dtime and tonumber(ilumination_remove_light_dtime) or 0.3
+local illumination_remove_light_time = tonumber(minetest.settings:get("illumination_remove_light_time")) or 0.3
 
 local player_lights = {}
 
@@ -9,23 +8,13 @@ local function can_replace(pos)
 	return nn == "air" or minetest.get_item_group(nn, "illumination_light") > 0
 end
 
-local function fix_light(pos)
-	local pmin = vector.subtract(pos, { x = 16, y = 16, z = 16 })
-	local pmax = vector.add(pos, { x = 16, y = 16, z = 16 })
-
-	return minetest.fix_light(pmin, pmax)
-end
-
 local function remove_light(pos)
-	local nn = minetest.get_node(pos).name
-	if minetest.get_item_group(nn, "illumination_light") > 0 then
-		if ilumination_remove_light_dtime <= 0 then
+	if pos and minetest.get_item_group(minetest.get_node(pos).name, "illumination_light") > 0 then
+		if illumination_remove_light_time <= 0 then
 			minetest.set_node(pos, {name = "air"})
-			fix_light(pos)
 			return
 		end
-
-		minetest.get_node_timer(pos):start(ilumination_remove_light_dtime)
+		minetest.get_node_timer(pos):start(illumination_remove_light_time)
 	end
 end
 
@@ -94,9 +83,7 @@ local function update_illumination(player, dtime)
 		end
 	end
 	-- No illumination
-	if old_pos then
-		remove_light(old_pos)
-	end
+	remove_light(old_pos)
 	player_lights[name].pos = nil
 end
 
@@ -115,7 +102,7 @@ end)
 
 minetest.register_on_leaveplayer(function(player)
 	local name = player:get_player_name()
-	if player_lights[name] and player_lights[name].pos then
+	if player_lights[name] then
 		remove_light(player_lights[name].pos)
 	end
 	player_lights[name] = nil
@@ -144,9 +131,8 @@ if minetest.get_modpath("3d_armor") then
 	end)
 end
 
-local light_on_timer = function(pos)
-	minetest.set_node(pos, { name = "air" })
-	fix_light(pos)
+local function light_on_timer (pos)
+	minetest.set_node(pos, {name = "air"})
 end
 
 -- Light node for every light level
@@ -177,7 +163,6 @@ minetest.register_lbm({
 	run_at_every_load = true,
 	action = function(pos)
 		minetest.set_node(pos, {name = "air"})
-		fix_light(pos)
 	end,
 })
 

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,5 +1,4 @@
-# The time waited before removing outdated illumination nodes
-# Set this to a larger value to leave behind a light trail. Set to 0 to 
-# guarentee clean removal but risks flickering. The default value balances 
-# between realism and visual smoothness.
-ilumination_remove_light_dtime (Time waited before removing illumination nodes) float 0.3 0.0 60.0
+# Set this to a larger value to leave behind a light trail.
+# Set to 0 to guarantee clean removal but risk flickering.
+# The default value balances between realism and visual smoothness.
+illumination_remove_light_time (Light lifetime) float 0.3 0.0 60.0

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,5 @@
+# The time waited before removing outdated illumination nodes
+# Set this to a larger value to leave behind a light trail. Set to 0 to 
+# guarentee clean removal but risks flickering. The default value balances 
+# between realism and visual smoothness.
+ilumination_remove_light_dtime (Time waited before removing illumination nodes) float 0.3 0.0 60.0


### PR DESCRIPTION
If the old node is removed and the new node is added in the same game tick, the client may render the removal of the old node before the addition of the new node, resulting in flickering as lighting updates.

This patch fixes this by adding a configuration key, ilumination_remove_light_dtime, to control how many seconds should the game wait before removing old illumination nodes. By adding a server- side delay, the addition of the new node happens almost certainly after the removal of the old node. Setting the value to 0 restores the original behavior.

One can set the value to some extraordinarily high values, e.g. 5 sec., to leave behind a light trail. Doing so might trigger lighting recalculation bugs; therefore, a call to fix_light is done every time an old node is removed. Some light may still persist due to out-of-sync client-side map data; that's not our business.

This PR is Ready for Review.